### PR TITLE
Update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,26 +41,26 @@ lazy val rules = project.settings(
   publish / skip := false,
   libraryDependencies ++= Seq(
     "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion,
-    "io.circe" %% "circe-core" % "0.13.0",
-    "io.circe" %% "circe-parser" % "0.13.0",
+    "io.circe" %% "circe-core" % "0.14.14",
+    "io.circe" %% "circe-parser" % "0.14.14",
   ),
 )
 
 lazy val input = project.settings(
   publish/skip := true,
   libraryDependencies ++= Seq(
-    "io.circe" %% "circe-core" % "0.14.7",
-    "io.circe" %% "circe-literal" % "0.14.7",
-    "org.typelevel" %% "jawn-parser" % "1.5.1",
+    "io.circe" %% "circe-core" % "0.14.14",
+    "io.circe" %% "circe-literal" % "0.14.14",
+    "org.typelevel" %% "jawn-parser" % "1.6.0",
   )
 )
 
 lazy val output = project.settings(
   publish/skip := true,
   libraryDependencies ++= Seq(
-    "io.circe" %% "circe-core" % "0.14.7",
-    "io.circe" %% "circe-literal" % "0.14.7",
-    "org.typelevel" %% "jawn-parser" % "1.5.1",
+    "io.circe" %% "circe-core" % "0.14.14",
+    "io.circe" %% "circe-literal" % "0.14.14",
+    "org.typelevel" %% "jawn-parser" % "1.6.0",
   )
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+resolvers ++= Resolver.sonatypeOssRepos("releases")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")


### PR DESCRIPTION
As titled, the main objective is to remove the warning from projects using it:
```
[info] Loading external rule(s) built against an old version of Scalafix (0.12.1).
[info] This might not be a problem, but in case you run into unexpected behavior, you
[info] should try a more recent version of the rules(s) if available. If that does
[info] not help, request the rule(s) maintainer to build against Scalafix 0.14.3
[info] or later, and downgrade Scalafix to 0.12.x (x>=1) for the time being.
```