### PR TITLE
Fix handling of literals in keys

### DIFF
--- a/input/src/main/scala/fix/Examples.scala
+++ b/input/src/main/scala/fix/Examples.scala
@@ -26,4 +26,12 @@ object Examples {
 
   val inception =
     json"""{"key3": ${json"""{"key2": ${obj} }"""} }"""
+
+  val key1 = "a"
+  val key2 = "b"
+  val dynamicKeys =
+    json"""{${key1}:"x", ${key2}:"y"}"""
+
+  val dynamicVals =
+    json"""{"x":${key1}, "y":${key2}}"""
 }

--- a/output/src/main/scala/fix/Examples.scala
+++ b/output/src/main/scala/fix/Examples.scala
@@ -32,4 +32,18 @@ object Examples {
     json"""{
       "key3" : ${json"""{"key2": ${obj} }"""}
     }"""
+
+  val key1 = "a"
+  val key2 = "b"
+  val dynamicKeys =
+    json"""{
+      ${key1} : "x",
+      ${key2} : "y"
+    }"""
+
+  val dynamicVals =
+    json"""{
+      "x" : ${key1},
+      "y" : ${key2}
+    }"""
 }


### PR DESCRIPTION
This PR fixes an issue when there are multiple literals as JSON keys, where it would only keep the first one. I've changed slightly the logic with the string replacement, to have different strings for each case, and map them to the `Term` at the time of replacement, so they are correctly substituted when going through the terms. 

Besides the test case that covers this, I also tested in the project where I found this bug and it now works as intended.